### PR TITLE
Possible mobile font fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'chicagoFLF', Arial, Helvetica, sans-serif;
-  src: url(./res/font/ChicagoFLF.woff) format(woff);
-  src: url(./res/font/ChicagoFLF.woff2) format(woff2); 
+  src: url(./res/font/ChicagoFLF.woff) format("woff"),
+        url(./res/font/ChicagoFLF.woff2) format("woff2"); 
 }
 * {
   font-family: 'chicagoFLF';
@@ -139,4 +139,4 @@ aside {
   font-size: 0.9rem;
   padding: 2em 0 0 0;
 }
-}
+} /* Closing bracket for @media */


### PR DESCRIPTION
Possible fix for the custom font refusing to render on mobile devices (tested on Android v11 and v12)

Even if it doesn't help, the rest of the code is fine, no need to roll back.
